### PR TITLE
cache npm ci for faster installing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,8 @@ on:
       - '**'
   workflow_dispatch:
 
+env:
+  NODE_VERSION: 20
 jobs:
   Build-Windows:
     runs-on: windows-latest
@@ -22,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
           cache-dependency-path: |
             package-lock.json
@@ -33,13 +35,13 @@ jobs:
         uses: actions/cache@v4
         with:
           path: angular-frontend/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('angular-frontend/package-lock.json') }}
+          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-${{ hashFiles('angular-frontend/package-lock.json') }}
       - name: Cache electron
         id: cache-electron
         uses: actions/cache@v4
         with:
           path: electron/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('electron/package-lock.json') }}
+          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-${{ hashFiles('electron/package-lock.json') }}
       - name: Create version.json, if it doesn't exist
         if: ${{ hashFiles('electron/src/version.json') == '' }}
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,18 @@ jobs:
             package-lock.json
             angular-frontend/package-lock.json
             electron/package-lock.json
+      - name: Cache angular-frontend
+        id: cache-angular-frontend
+        uses: actions/cache@v4
+        with:
+          path: angular-frontend/node_modules
+          key: ${{ runner.os }}-${{ hashFiles('angular-frontend/package-lock.json') }}
+      - name: Cache electron
+        id: cache-electron
+        uses: actions/cache@v4
+        with:
+          path: electron/node_modules
+          key: ${{ runner.os }}-${{ hashFiles('electron/package-lock.json') }}
       - name: Create version.json, if it doesn't exist
         if: ${{ hashFiles('electron/src/version.json') == '' }}
         run: |
@@ -35,8 +47,14 @@ jobs:
           $electronVersion = jq '.version' 'electron/package.json'
           echo "console.log(JSON.stringify({generatedAt: new Date().toISOString(), angularVersion: $($angularVersion), electronVersion: $($electronVersion)}))" | node - > electron/src/version.json
           type electron/src/version.json
-      - name: Install NPM-Dependencies
-        run: npm run install:all
+      - name: Install angular-frontend NPM-Dependencies
+        if: ${{steps.cache-angular-frontend.outputs.cache-hit != 'true'}}
+        working-directory: angular-frontend
+        run: npm ci
+      - name: Install electron NPM-Dependencies
+        if: ${{steps.cache-electron.outputs.cache-hit != 'true'}}
+        working-directory: electron
+        run: npm ci
       - name: Build Project
         run: npm run build
       - name: Test Angular

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,13 +35,13 @@ jobs:
         uses: actions/cache@v4
         with:
           path: angular-frontend/node_modules
-          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-${{ hashFiles('angular-frontend/package-lock.json') }}
+          key: ${{ runner.os }}-${{runner.arch}}-${{ env.NODE_VERSION }}-${{ hashFiles('angular-frontend/package-lock.json') }}
       - name: Cache electron
         id: cache-electron
         uses: actions/cache@v4
         with:
           path: electron/node_modules
-          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-${{ hashFiles('electron/package-lock.json') }}
+          key: ${{ runner.os }}-${{runner.arch}}-${{ env.NODE_VERSION }}-${{ hashFiles('electron/package-lock.json') }}
       - name: Create version.json, if it doesn't exist
         if: ${{ hashFiles('electron/src/version.json') == '' }}
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,11 +50,11 @@ jobs:
       - name: Install angular-frontend NPM-Dependencies
         if: ${{steps.cache-angular-frontend.outputs.cache-hit != 'true'}}
         working-directory: angular-frontend
-        run: npm ci
+        run: npm ci --no-audit
       - name: Install electron NPM-Dependencies
         if: ${{steps.cache-electron.outputs.cache-hit != 'true'}}
         working-directory: electron
-        run: npm ci
+        run: npm ci --no-audit
       - name: Build Project
         run: npm run build
       - name: Test Angular

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,13 +35,13 @@ jobs:
         uses: actions/cache@v4
         with:
           path: angular-frontend/node_modules
-          key: ${{ runner.os }}-${{runner.arch}}-${{ env.NODE_VERSION }}-${{ hashFiles('angular-frontend/package-lock.json') }}
+          key: node_modules-angular_frontend-${{ runner.os }}-${{runner.arch}}-${{ env.NODE_VERSION }}-${{ hashFiles('angular-frontend/package-lock.json') }}
       - name: Cache electron
         id: cache-electron
         uses: actions/cache@v4
         with:
           path: electron/node_modules
-          key: ${{ runner.os }}-${{runner.arch}}-${{ env.NODE_VERSION }}-${{ hashFiles('electron/package-lock.json') }}
+          key: node_modules-electron-${{ runner.os }}-${{runner.arch}}-${{ env.NODE_VERSION }}-${{ hashFiles('electron/package-lock.json') }}
       - name: Create version.json, if it doesn't exist
         if: ${{ hashFiles('electron/src/version.json') == '' }}
         run: |


### PR DESCRIPTION
## Summary

**Brief description about the content of your PR and its improvements for the project.**

1. What problem does this PR solve? Which concept, bug, or requirement does it address?

This pr addresses the issue, that installing npm dependencies in github actions take a long time.

2. Please add context to the improvements: reference an issue ("Resolves #<your issue id here>"), a user story, or explain the improvements in documentation, code, or UX.

When pushing new commits, github spends a long time installing npm dependencies vs actually building and testing the commit.

## Design Decisions

**Describe the way your implementation works or what design decisions you made if applicable.**

Which are the main files and concepts you changed or introduced?

I only changed the github workflow file.

I added caching for the individual node_module folders and only install dependencies, when the cache doesn't exist yet

## Testing

**Briefly explain how it can be tested—either with commands, manual steps, or test files.**

1. Provide a description of the expected behavior.

The actions should now only install the npm dependencies when nessesary.

2. Describe how you tested the changes.

I ran the action twice. Once, so the caches can be populated and another time, so I can check if the cache is being successfully used.

3. Is there still unexpected behaviour which needs to be addressed in the future?

No

## Checklist

Make sure you

- [x] have read the [contribution guidelines](../CONTRIBUTION.md)
- [x] have added necessary unit/e2e tests if necessary.
- [x] have added documentation if necessary.