### PR TITLE
Adapt Polling and disconnect WebSocket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Formatting needs to be similar to the dataformat of the old OmnAIView data exports. For more infos, see comments in code.
 - Added automatic device polling every 15 Seconds (#35)
 - Add axis mode: Allow to switch between absolute and relative x-axis timestamps(#58)
+- Added webSocket disconnect and disable device polling while active WebSocket (#97)
 
 ### Changed 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Formatting needs to be similar to the dataformat of the old OmnAIView data exports. For more infos, see comments in code.
 - Added automatic device polling every 15 Seconds (#35)
 - Add axis mode: Allow to switch between absolute and relative x-axis timestamps(#58)
-- Added webSocket disconnect and disable device polling while active WebSocket (#97)
+- Add webSocket disconnect and disable device polling while active WebSocket (#97)
 
 ### Changed 
 

--- a/angular-frontend/src/app/omnai-datasource/omnai-scope-server/devicelist.component.html
+++ b/angular-frontend/src/app/omnai-datasource/omnai-scope-server/devicelist.component.html
@@ -1,3 +1,6 @@
+@if (isConnected()) {
+  <button (click)="disconnectWebsocket()">Disconnect WebSocket</button>
+}
 @for (device of devices(); track device.UUID) {
 <ul>
     <li>

--- a/angular-frontend/src/app/omnai-datasource/omnai-scope-server/devicelist.component.html
+++ b/angular-frontend/src/app/omnai-datasource/omnai-scope-server/devicelist.component.html
@@ -1,5 +1,5 @@
 @if (isConnected()) {
-  <button (click)="disconnectWebsocket()" id="buttonDisconnectWebsocket">Disconnect WebSocket</button>
+  <button (click)="disconnectWebsocket()" id="buttonDisconnectWebsocket">🛑</button>
 }
 @for (device of devices(); track device.UUID) {
 <ul>

--- a/angular-frontend/src/app/omnai-datasource/omnai-scope-server/devicelist.component.html
+++ b/angular-frontend/src/app/omnai-datasource/omnai-scope-server/devicelist.component.html
@@ -1,5 +1,5 @@
 @if (isConnected()) {
-  <button (click)="disconnectWebsocket()">Disconnect WebSocket</button>
+  <button (click)="disconnectWebsocket()" id="buttonDisconnectWebsocket">Disconnect WebSocket</button>
 }
 @for (device of devices(); track device.UUID) {
 <ul>

--- a/angular-frontend/src/app/omnai-datasource/omnai-scope-server/devicelist.component.ts
+++ b/angular-frontend/src/app/omnai-datasource/omnai-scope-server/devicelist.component.ts
@@ -12,6 +12,8 @@ import { OmnAIScopeDataService } from './live-data.service';
 export class DeviceListComponent {
     readonly #deviceHandler = inject(OmnAIScopeDataService);
     devices = this.#deviceHandler.devices
+    isConnected = this.#deviceHandler.isConnected
 
     getDevicesList = this.#deviceHandler.getDevices.bind(this.#deviceHandler)
+    disconnectWebsocket = this.#deviceHandler.disconnect.bind(this.#deviceHandler)
 }

--- a/angular-frontend/src/app/omnai-datasource/omnai-scope-server/live-data.service.ts
+++ b/angular-frontend/src/app/omnai-datasource/omnai-scope-server/live-data.service.ts
@@ -3,7 +3,7 @@ import { HttpClient } from '@angular/common/http';
 import { computed, inject, Injectable, signal, DestroyRef } from '@angular/core';
 import { DataSource } from '../../source-selection/data-source-selection.service';
 import {catchError, Observable, of, Subject, switchMap, takeUntil, timer} from 'rxjs';
-import {map} from 'rxjs/operators';
+import {map, filter} from 'rxjs/operators';
 import { BackendPortService } from './backend-port.service';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
@@ -58,6 +58,7 @@ export class OmnAIScopeDataService implements DataSource {
     const pollInterval_ms = 15 * 1000;
     timer(0, pollInterval_ms )
       .pipe(
+        filter(() => !this.isConnected() && this.port() !== null),
         switchMap(() => this.getDevices()),
         takeUntilDestroyed(this.destroyRef)
       )


### PR DESCRIPTION
Summary
> This PR adds the option to disconnect the current WebSocket Connection. The button is only displayed while the WS Connection is active. Also the getDevices is only called while the WebSocket is inactive due to the Backend being unable to answer /UUID Requests when active as WS.

🛠 Type of change
> New Feature

How to test
1. Expected behavior
> getDevices is only called during inactive WS Connection. Button is clickable while WS is active. getDevices resumes polling after WS is disconnected.

2. Steps to reproduce
> Connect a scope, check if the polling works. Start data/ws. Click the button and the data should stop. getDevices should resume.

3. Is there still unexpected behaviour which needs to be addressed in the future?
> No