### PR TITLE
feat: Change start data to play button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Formatting needs to be similar to the dataformat of the old OmnAIView data expor
 - Privacy oriented default setting to not share data with Google (#82)
 - Fixed ci and `package-lock.json` files to allow installing the project with `npm ci` (#83)
 - Stop-Button for Random Data Server (#115)
+- Change start-data button to mat-icon play_arrow button (#107)
 
 
 ### Removed 

--- a/angular-frontend/src/app/source-selection/start-data-from-source.component.ts
+++ b/angular-frontend/src/app/source-selection/start-data-from-source.component.ts
@@ -3,13 +3,17 @@ import { Component, inject } from '@angular/core';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { DataSourceSelectionService } from './data-source-selection.service';
 import { SourceSelectModalComponent } from './source-select-modal.component';
+import { MatIconModule } from '@angular/material/icon';
+
 
 @Component({
     selector: 'app-start-data-button',
     standalone: true,
-    imports: [MatDialogModule],
+    imports: [MatDialogModule, MatIconModule],
     template: `
-    <button (click)="openModal()">Start Data</button>
+    <button mat-icon-button (click)="openModal()" aria-label="Start Data">
+      <mat-icon>play_arrow</mat-icon>
+    </button>
   `
 })
 export class StartDataButtonComponent {


### PR DESCRIPTION
## Summary

This PR changes the "start data" button to a mat-icon "play_arrow" button. Regarding #105 this should lead to a more intuitive usage of the software, designed after the cassette recorder modell, language independend.


## Design Decisions

Change button to mat-icon button. 


## Testing

1. Provide a description of the expected behavior.

The start data button should behave as before. 
The start data button should be visible via a "Play" icon. 

4. Is there still unexpected behaviour which needs to be addressed in the future?
No

## Checklist

Make sure you

- [x] have read the [contribution guidelines](../CONTRIBUTION.md)
- [x] have added necessary unit/e2e tests if necessary.
- [x] have added documentation if necessary.