### PR TITLE
feat(setup): Add CI workflow for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,9 @@
-name: CI-and-Release
+# Create new release via github CI on merge with master 
+# Versioning is calculated from git tags 
+## semver:minor, semver:major, semver:patch set which version number should be increased 
+## prerelease:alpha, perelease:beta set the release as a prerelease verison 
+## release:skip skip new release creation on merge 
+name: CI-for-Release
 
 on:
   push:
@@ -14,7 +19,7 @@ permissions:
   actions: read
 
 jobs:
-  bump:
+  bump: # creates a version tag from last version and PR labels 
     runs-on: ubuntu-latest
     outputs:
       sha:   ${{ steps.commit.outputs.commit_sha }}   
@@ -106,7 +111,7 @@ jobs:
           echo "new_tag=$new_tag"   >> "$GITHUB_OUTPUT"
           echo "plain_ver=$next"    >> "$GITHUB_OUTPUT"
 
-      - name: Update package.json
+      - name: Update package.json # updates the package.json files in the master repository to fit new version before building 
         run: |
           for f in angular-frontend/package.json electron/package.json package.json; do
             npx json -I -f "$f" -e "this.version='${{ steps.bump.outputs.plain_ver }}'"
@@ -123,9 +128,9 @@ jobs:
           git tag "${{ steps.bump.outputs.new_tag }}" ${{ steps.commit.outputs.sha }}
           git push origin "${{ steps.bump.outputs.new_tag }}"
 
-  build-windows:
+  build-windows: 
     needs: bump
-    runs-on: windows-latest
+    runs-on: windows-latest # create new windows artifact 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -166,7 +171,7 @@ jobs:
             electron/out/make/squirrel.windows/x64/*.nupkg
             electron/out/make/squirrel.windows/x64/*.exe
   
-  release:
+  release: # create new release in Github release section 
     needs: [bump, build-windows]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,185 @@
+name: CI-and-Release
+
+on:
+  push:
+    branches: ["master"]         
+  workflow_dispatch:
+
+env:
+  NODE_VERSION: 20
+
+permissions:
+  contents: write
+  pull-requests: read
+  actions: read
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    outputs:
+      sha:   ${{ steps.commit.outputs.commit_sha }}   
+      tag:   ${{ steps.bump.outputs.new_tag }}         
+      plain: ${{ steps.bump.outputs.plain_ver }}       
+      pre:   ${{ steps.rel.outputs.pre }}     
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Determine release type and version from PR labels
+        id: rel
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const prs = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner,
+              repo,
+              commit_sha: context.sha
+            });
+
+            if (!prs.data.length) {
+              core.setFailed('No PR for this commit');
+              return;
+            }
+
+            const labels = prs.data[0].labels.map(l => l.name);
+
+            if (labels.includes('release:skip')) {
+              core.exportVariable('SKIP_RELEASE', 'true');
+              return;
+            }
+
+            core.setOutput(
+              'bump',
+              ['major','minor','patch'].find(t => labels.includes(`semver:${t}`)) ?? 'patch'
+            );
+            core.setOutput(
+              'pre',
+              ['alpha','beta'].find(p => labels.includes(`prerelease:${p}`)) ?? ''
+            );
+
+      - name: Stop if release:skip
+        if: env.SKIP_RELEASE == 'true'
+        run: echo "Skip release" && exit 0
+
+      - name: Calculate new version from latest version 
+        id: bump
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --prune --tags
+
+          latest=$(git tag -l \
+                   | sed 's/^v//' \
+                   | grep -E '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z\.-]+)?$' \
+                   | sort -V \
+                   | tail -n1)
+          [[ -z "$latest" ]] && latest="0.0.0"
+          echo "Latest tag: $latest"
+
+          bump="${{ steps.rel.outputs.bump }}"
+          pre="${{ steps.rel.outputs.pre }}"
+          preflag=""
+          [[ -n "$pre" ]] && preflag="--preid $pre"
+
+             next=$(npx semver "$latest" -i "${{ steps.rel.outputs.bump }}" \
+                 $( [[ -n "${{ steps.rel.outputs.pre }}" ]] && echo --preid ${{ steps.rel.outputs.pre }}))
+          new_tag="v$next"                   
+
+          echo "new_tag=$new_tag"   >> "$GITHUB_OUTPUT"
+          echo "plain_ver=$next"    >> "$GITHUB_OUTPUT"
+
+      - name: Update package.json
+        run: |
+          for f in angular-frontend/package.json electron/package.json package.json; do
+            npx json -I -f "$f" -e "this.version='${{ steps.bump.outputs.plain_ver }}'"
+          done
+      - name: Commit bumped versions
+        id: commit       
+        uses: stefanzweifel/git-auto-commit-action@v6      
+        with:
+          branch: master 
+          commit_message: "chore: bump to ${{ steps.bump.outputs.new_tag }} [skip ci]"
+          file_pattern: angular-frontend/package.json electron/package.json package.json
+      - name: Create git tag         
+        run: |
+          git tag "${{ steps.bump.outputs.new_tag }}" ${{ steps.commit.outputs.sha }}
+          git push origin "${{ steps.bump.outputs.new_tag }}"
+
+  build-windows:
+    needs: bump
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.bump.outputs.sha }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Cache node_modules
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: node_modules-${{ runner.os }}-${{ runner.arch }}-node_${{ env.NODE_VERSION }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Install deps
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: npm ci --no-audit --no-fund
+
+      - name: Build
+        run: npm run build
+
+      - name: Angular tests
+        working-directory: angular-frontend
+        run: npx ng test --watch=false
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: OmnAIView-Windows
+          path: |
+            electron/out/make/squirrel.windows/x64/RELEASES
+            electron/out/make/squirrel.windows/x64/*.nupkg
+            electron/out/make/squirrel.windows/x64/*.exe
+  
+  release:
+    needs: [bump, build-windows]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.bump.outputs.sha }}
+
+      - name: Download Windows artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: OmnAIView-Windows   
+          path: .             
+    
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name:   ${{ needs.bump.outputs.tag }}
+          prerelease: ${{ needs.bump.outputs.pre != '' }}
+          files: |                  
+            ./*.exe
+            ./*.nupkg
+            ./RELEASES
+          fail_on_unmatched_files: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,12 +87,21 @@ jobs:
 
           bump="${{ steps.rel.outputs.bump }}"
           pre="${{ steps.rel.outputs.pre }}"
-          preflag=""
-          [[ -n "$pre" ]] && preflag="--preid $pre"
+          if [[ -n "$pre" ]]; then
+            case "$bump" in
+              patch)  bump="prepatch"  ;;
+              minor)  bump="preminor"  ;;
+              major)  bump="premajor"  ;;
+            esac
+          fi
 
-             next=$(npx semver "$latest" -i "${{ steps.rel.outputs.bump }}" \
-                 $( [[ -n "${{ steps.rel.outputs.pre }}" ]] && echo --preid ${{ steps.rel.outputs.pre }}))
-          new_tag="v$next"                   
+          if [[ -n "$pre" ]]; then
+            next=$(npx semver "$latest" -i "$bump" --preid "$pre")
+          else
+            next=$(npx semver "$latest" -i "$bump")
+          fi   
+
+          new_tag="v$next"              
 
           echo "new_tag=$new_tag"   >> "$GITHUB_OUTPUT"
           echo "plain_ver=$next"    >> "$GITHUB_OUTPUT"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Formatting needs to be similar to the dataformat of the old OmnAIView data expor
 - Update contribution workflow (#89)
 - Add darkmode via button toggle (#121)
 - Add workshop/advanced mode for car repair shops (#118)
+- Add CI for Release (#123)
 
 
 ### Changed 


### PR DESCRIPTION
## Checklist
Make sure you

- [x] have read the [contribution guidelines](../CONTRIBUTION.md),
- [x] given this PR a concise and imperative title, <!-- e.g. "Fix memory leak in DeviceService" or "Add dark-mode toggle" -->
- [x] have added necessary unit/e2e tests if necessary,
- [x] have added documentation if necessary,
- [x] have documented the changes in the [CHANGELOG.md](../CHANGELOG.md).

## 🛠 Type of change
<!-- Tick **all that apply** and delete the unused ones. -->
- [x] CI / tooling

## Summary
<!-- A description of 1–3 sentences of what this PR does and *why*
What problem does this PR solve?
Which concept, bug, or requirement does it address? -->

This PR adds a CI for new releases. 

A new release is created whenever code is pushed on the master branch. 
A release contains : 
- a version number 
- a type: alpha, beta , no prerelease 
- the corresponding executable for windows 
-  generated release notes

Issue number *Add issue number here*

## 📝 Design Decisions
<!-- Changes in detail (files, concepts)
>Describe the way your implementation works or what design decisions you made if applicable.
>Which are the main files and concepts you changed or introduced? -->

The CI follows this steps: 
1. Calculate new version 
   > The version gets calculated from the highest available tags + labels set for the merge 
2. Update the package.json versions 
   > The package.json, angular-frontend/package.json, electron/package.json versions get updated and are commited to the master 
3. Create new tag 
   > Create new tag from new version number 
3. Build artifact 
    > The artifact is build for windows 
5. Create release + add build artifact to release 
   > Creates a new release from the new tag in the github with automatic release notes 
   > Adds windows artifacts to the asset section of the release 

The labels work as follows: 

semver:minor, semver:major, semver:patch --> Create new version number that either increases the major, minor or patch number 

prerelease:alpha, prerelease:beta --> Create an extra -alpha or -beta to the release, adds it as a prerelease 

release:skip --> Skip new release process , can be used for example when only documentation or CI is updated 

## How to test

Tested this workflow on my own fork . 

To reproduce copy and paste the workflow in your own fork. Add the labels to the labels section of your repository. 
Push the changes via PR with set labels to the master. Depending on the labels and the latest v* tag in your repository you should receive different outputs for the releases. 

### 3. Is there still unexpected behaviour which needs to be addressed in the future?

There are no error handlings if someone uses the labels in a wrong pattern. For example using both semver:minor and semver:patch as labels for a PR. 

