### PR TITLE
Add stop and delete functionality to start button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Formatting needs to be similar to the dataformat of the old OmnAIView data expor
 - Update contribution workflow (#89)
 - Add darkmode via button toggle (#121)
 - Add workshop/advanced mode for car repair shops (#118)
+- Add stop and delete functionality to start button (#126)
 
 
 ### Changed 

--- a/angular-frontend/src/app/graph/graph.component.ts
+++ b/angular-frontend/src/app/graph/graph.component.ts
@@ -17,7 +17,7 @@ import { select } from 'd3-selection';
 import { timeFormat } from 'd3-time-format';
 import { DeviceListComponent } from "../omnai-datasource/omnai-scope-server/devicelist.component";
 import { ResizeObserverDirective } from '../shared/resize-observer.directive';
-import { StartDataButtonComponent } from "../source-selection/start-data-from-source.component";
+import { StartDataButtonComponent } from "../source-selection/start-data-button.component";
 import { DataSourceService } from './graph-data.service';
 import { makeXAxisTickFormatter, type xAxisMode } from './x-axis-formatter.utils';
 import { DarkmodeComponent } from '../darkmode/darkmode.component';

--- a/angular-frontend/src/app/omnai-datasource/csv-file-import/csv-file-import.service.ts
+++ b/angular-frontend/src/app/omnai-datasource/csv-file-import/csv-file-import.service.ts
@@ -22,8 +22,8 @@ export class CsvFileImportService implements DataSource {
   connect() {
     this.dialog.open(CsvFileSelectModalComponent)
   }
-  disconnect(): void {
-  }
+  disconnect(): void { }
+  clearData(): void { }
   private readonly $data = signal<Record<string, DataFormat[]>>({});
   readonly data = this.$data.asReadonly();
 

--- a/angular-frontend/src/app/omnai-datasource/csv-file-import/csv-file-import.service.ts
+++ b/angular-frontend/src/app/omnai-datasource/csv-file-import/csv-file-import.service.ts
@@ -22,6 +22,8 @@ export class CsvFileImportService implements DataSource {
   connect() {
     this.dialog.open(CsvFileSelectModalComponent)
   }
+  disconnect(): void {
+  }
   private readonly $data = signal<Record<string, DataFormat[]>>({});
   readonly data = this.$data.asReadonly();
 

--- a/angular-frontend/src/app/omnai-datasource/omnai-scope-server/devicelist.component.html
+++ b/angular-frontend/src/app/omnai-datasource/omnai-scope-server/devicelist.component.html
@@ -1,6 +1,3 @@
-@if (isLiveDataConnected() || isRandomDataConnected()) {
-  <button (click)="disconnectSource()" id="buttonDisconnectSource">🛑</button>
-}
 @for (device of devices(); track device.UUID) {
 <ul>
     <li>

--- a/angular-frontend/src/app/omnai-datasource/omnai-scope-server/devicelist.component.ts
+++ b/angular-frontend/src/app/omnai-datasource/omnai-scope-server/devicelist.component.ts
@@ -2,7 +2,6 @@
 
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { OmnAIScopeDataService } from './live-data.service';
-import { DummyDataService } from '../random-data-server/random-data.service';
 
 @Component({
     selector: 'app-device-list',
@@ -11,18 +10,7 @@ import { DummyDataService } from '../random-data-server/random-data.service';
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class DeviceListComponent {
-    readonly #deviceHandler = inject(OmnAIScopeDataService);
-    readonly #randomDataHandler = inject(DummyDataService);
-    devices = this.#deviceHandler.devices
-    isLiveDataConnected = this.#deviceHandler.isConnected
-    isRandomDataConnected = this.#randomDataHandler.isConnected
-
-    getDevicesList = this.#deviceHandler.getDevices.bind(this.#deviceHandler)
-    disconnectSource = () => {
-        if (this.#deviceHandler.isConnected()) {
-            this.#deviceHandler.disconnect();
-        } else if (this.#randomDataHandler.isConnected()) {
-            this.#randomDataHandler.disconnect();
-        }
-    };
+    private readonly deviceHandler = inject(OmnAIScopeDataService);
+    protected readonly devices = this.deviceHandler.devices;
+    getDevicesList = this.deviceHandler.getDevices.bind(this.deviceHandler);
 }

--- a/angular-frontend/src/app/omnai-datasource/omnai-scope-server/live-data.service.ts
+++ b/angular-frontend/src/app/omnai-datasource/omnai-scope-server/live-data.service.ts
@@ -169,6 +169,10 @@ export class OmnAIScopeDataService implements DataSource {
     }
   }
 
+  clearData(): void {
+    this.data.set({});
+  }
+
   // Typprüfung für OmnAI-Daten-Nachrichten
   private isOmnAIDataMessage(message: any): boolean {
     if (typeof message !== 'object' || message === null) return false;

--- a/angular-frontend/src/app/omnai-datasource/random-data-server/random-data.service.ts
+++ b/angular-frontend/src/app/omnai-datasource/random-data-server/random-data.service.ts
@@ -36,4 +36,8 @@ export class DummyDataService implements DataSource {
         this.subscription = null;
         this.isConnected.set(false);
     }
+
+    clearData(): void {
+        this._data.set({});
+    }
 }

--- a/angular-frontend/src/app/source-selection/data-source-selection.service.ts
+++ b/angular-frontend/src/app/source-selection/data-source-selection.service.ts
@@ -12,6 +12,7 @@ export interface DataPoint {
 /** Your expected DataSource interface */
 export interface DataSource {
     connect(): unknown;
+    disconnect(): void;
     data: Signal<Record<string, DataFormat[]>>
 }
 
@@ -37,6 +38,7 @@ export class DataSourceSelectionService {
             name: 'OmnAIScope',
             description: 'Live data from connected OmnAIScope devices',
             connect: this.liveDataService.connect.bind(this.liveDataService),
+            disconnect: this.liveDataService.connect.bind(this.liveDataService),
             data: this.liveDataService.data
         },
         {
@@ -44,14 +46,16 @@ export class DataSourceSelectionService {
             name: 'Random Dummy Data',
             description: 'Random generated data points',
             connect: this.dummyDataService.connect.bind(this.dummyDataService),
+            disconnect: this.dummyDataService.disconnect.bind(this.dummyDataService),
             data: this.dummyDataService.data
         },
         {
-          id: 'csv-file',
-          name: 'CSV Data',
-          description: 'Import a CSV file',
-          connect: this.csvDataService.connect.bind(this.csvDataService),
-          data: this.csvDataService.data
+            id: 'csv-file',
+            name: 'CSV Data',
+            description: 'Import a CSV file',
+            connect: this.csvDataService.connect.bind(this.csvDataService),
+            disconnect: this.csvDataService.connect.bind(this.csvDataService),
+            data: this.csvDataService.data
         }
     ]);
     readonly availableSources = this._availableSources.asReadonly();

--- a/angular-frontend/src/app/source-selection/data-source-selection.service.ts
+++ b/angular-frontend/src/app/source-selection/data-source-selection.service.ts
@@ -13,6 +13,7 @@ export interface DataPoint {
 export interface DataSource {
     connect(): unknown;
     disconnect(): void;
+    clearData(): void;
     data: Signal<Record<string, DataFormat[]>>
 }
 
@@ -38,7 +39,8 @@ export class DataSourceSelectionService {
             name: 'OmnAIScope',
             description: 'Live data from connected OmnAIScope devices',
             connect: this.liveDataService.connect.bind(this.liveDataService),
-            disconnect: this.liveDataService.connect.bind(this.liveDataService),
+            disconnect: this.liveDataService.disconnect.bind(this.liveDataService),
+            clearData: this.liveDataService.clearData.bind(this.liveDataService),
             data: this.liveDataService.data
         },
         {
@@ -47,6 +49,7 @@ export class DataSourceSelectionService {
             description: 'Random generated data points',
             connect: this.dummyDataService.connect.bind(this.dummyDataService),
             disconnect: this.dummyDataService.disconnect.bind(this.dummyDataService),
+            clearData: this.dummyDataService.clearData.bind(this.dummyDataService),
             data: this.dummyDataService.data
         },
         {
@@ -54,7 +57,8 @@ export class DataSourceSelectionService {
             name: 'CSV Data',
             description: 'Import a CSV file',
             connect: this.csvDataService.connect.bind(this.csvDataService),
-            disconnect: this.csvDataService.connect.bind(this.csvDataService),
+            disconnect: this.csvDataService.disconnect.bind(this.csvDataService),
+            clearData: this.csvDataService.clearData.bind(this.csvDataService),
             data: this.csvDataService.data
         }
     ]);

--- a/angular-frontend/src/app/source-selection/source-select-modal.component.html
+++ b/angular-frontend/src/app/source-selection/source-select-modal.component.html
@@ -13,6 +13,9 @@
                     @if (source.description; as description) {
                         <mat-card-content>{{ description }}</mat-card-content>
                     }
+                    <mat-card-actions align="end">
+                        <button mat-button (click)="select(source)">Select</button>
+                    </mat-card-actions>
                 </mat-card>
             </li>
         }
@@ -21,6 +24,6 @@
 </mat-dialog-content>
 
 <mat-dialog-actions align="end">
-    <!--Buttons are disabled when no source is selected, "Clear Selection" button uses different style for visual contrast-->
+    <!--Button is disabled when no source is selected-->
     <button mat-button [mat-dialog-close]="selected()" [disabled]="!selected()">Start</button>
 </mat-dialog-actions>

--- a/angular-frontend/src/app/source-selection/source-select-modal.component.html
+++ b/angular-frontend/src/app/source-selection/source-select-modal.component.html
@@ -13,9 +13,6 @@
                     @if (source.description; as description) {
                         <mat-card-content>{{ description }}</mat-card-content>
                     }
-                    <mat-card-actions  align="end">
-                        <button mat-button (click)="select(source)">Select</button>
-                    </mat-card-actions>
                 </mat-card>
             </li>
         }
@@ -23,8 +20,7 @@
     
 </mat-dialog-content>
 
-<mat-dialog-actions>
+<mat-dialog-actions align="end">
     <!--Buttons are disabled when no source is selected, "Clear Selection" button uses different style for visual contrast-->
-    <button mat-flat-button [class]="selected()? 'error' : ''" [disabled]="!selected()" (click)="clear()">Clear Selection</button>  
     <button mat-button [mat-dialog-close]="selected()" [disabled]="!selected()">Start</button>
 </mat-dialog-actions>

--- a/angular-frontend/src/app/source-selection/source-select-modal.component.ts
+++ b/angular-frontend/src/app/source-selection/source-select-modal.component.ts
@@ -14,17 +14,10 @@ import {MatCardModule, MatCardHeader, MatCardContent, MatCardActions} from '@ang
 })
 export class SourceSelectModalComponent {
     private readonly datasourceService = inject(DataSourceSelectionService);
+    protected readonly sources = this.datasourceService.availableSources;
+    protected readonly selected = this.datasourceService.currentSource;
 
-    readonly sources = this.datasourceService.availableSources;
-    readonly selected = this.datasourceService.currentSource;
-
-
-    private readonly dialogRef = inject(MatDialogRef<SourceSelectModalComponent>);
     select(source: DataSourceInfo) {
         this.datasourceService.selectSource(source);
-    }
-
-    clear() {
-        this.datasourceService.clearSelection();
     }
 }

--- a/angular-frontend/src/app/source-selection/start-data-button.component.ts
+++ b/angular-frontend/src/app/source-selection/start-data-button.component.ts
@@ -11,10 +11,11 @@ import { AdvancedModeService } from '../advanced-mode/advanced-mode.service';
     standalone: true,
     imports: [MatDialogModule, MatIconModule],
     template: `
-    <button mat-icon-button (click)="toggleStartButton()" aria-label="Start Data" style="display: flex; padding: .3em" id="start-button">
-      <mat-icon>{{ measurementIsStarted ? 'stop' : 'play_arrow' }}</mat-icon>
-    </button>
-  `
+        <button mat-icon-button (click)="toggleStartButton()" aria-label="Start Data" id="start-button">
+        <mat-icon>{{ measurementIsStarted ? 'stop' : 'play_arrow' }}</mat-icon>
+        </button>
+    `,
+    styles: `button { display: flex; padding: .3em }`,
 })
 export class StartDataButtonComponent {
     private readonly dialog = inject(MatDialog);

--- a/angular-frontend/src/app/source-selection/start-data-from-source.component.ts
+++ b/angular-frontend/src/app/source-selection/start-data-from-source.component.ts
@@ -11,8 +11,8 @@ import { AdvancedModeService } from '../advanced-mode/advanced-mode.service';
     standalone: true,
     imports: [MatDialogModule, MatIconModule],
     template: `
-    <button mat-icon-button (click)="openModal()" aria-label="Start Data">
-      <mat-icon>play_arrow</mat-icon>
+    <button mat-icon-button (click)="toggleStartButton()" aria-label="Start Data" style="display: flex; padding: .3em" id="start-button">
+      <mat-icon>{{ measurementIsStarted ? 'stop' : 'play_arrow' }}</mat-icon>
     </button>
   `
 })
@@ -20,7 +20,15 @@ export class StartDataButtonComponent {
     private readonly dialog = inject(MatDialog);
     private readonly datasource = inject(DataSourceSelectionService);
     private readonly advancedMode = inject(AdvancedModeService);
+
+    protected measurementIsStarted: boolean = false;
+
+    resetAllData(): void {
+        // this.datasource.currentSource()?.data = {};
+    }
+
     openModal(): void {
+        this.resetAllData();
         if (this.advancedMode.enabled()) {
             const dialogRef = this.dialog.open(SourceSelectModalComponent, {
                 width: '60vw'
@@ -39,5 +47,18 @@ export class StartDataButtonComponent {
                 OmnAIScope.connect();
             }
         }
+    }
+
+    stopMeasurement(): void {
+        try {
+            this.datasource.currentSource()?.disconnect();
+        } catch(error: unknown) {
+            this.datasource.clearSelection();
+        }
+    }
+
+    toggleStartButton(): void {
+        this.measurementIsStarted ? this.stopMeasurement() : this.openModal();
+        this.measurementIsStarted = !this.measurementIsStarted;
     }
 }

--- a/angular-frontend/src/app/source-selection/start-data-from-source.component.ts
+++ b/angular-frontend/src/app/source-selection/start-data-from-source.component.ts
@@ -23,12 +23,14 @@ export class StartDataButtonComponent {
 
     protected measurementIsStarted: boolean = false;
 
-    resetAllData(): void {
-        // this.datasource.currentSource()?.data = {};
+    clearAllData(): void {
+        this.datasource.availableSources().forEach( (source) => {
+            source.clearData();
+        });
     }
 
     openModal(): void {
-        this.resetAllData();
+        this.clearAllData();
         if (this.advancedMode.enabled()) {
             const dialogRef = this.dialog.open(SourceSelectModalComponent, {
                 width: '60vw'
@@ -50,11 +52,7 @@ export class StartDataButtonComponent {
     }
 
     stopMeasurement(): void {
-        try {
-            this.datasource.currentSource()?.disconnect();
-        } catch(error: unknown) {
-            this.datasource.clearSelection();
-        }
+        this.datasource.currentSource()?.disconnect();
     }
 
     toggleStartButton(): void {


### PR DESCRIPTION
## Checklist
Make sure you

- [x] have read the [contribution guidelines](../CONTRIBUTION.md),
- [x] given this PR a concise and imperative title, <!-- e.g. "Fix memory leak in DeviceService" or "Add dark-mode toggle" -->
- [ ] have added necessary unit/e2e tests if necessary,
- [ ] have added documentation if necessary,
- [ ] have documented the changes in the [CHANGELOG.md](../CHANGELOG.md).

## 🛠 Type of change
<!-- Tick **all that apply** and delete the unused ones. -->

- [x] New feature
- [x] Refactor (no functional change)

## Summary
<!-- A description of 1–3 sentences of what this PR does and *why*
What problem does this PR solve?
Which concept, bug, or requirement does it address? -->

This PR adresses the feature to have only one button to start, stop and restart a measurement.

Issue number #106 and #108.

## 📝 Design Decisions
<!-- Changes in detail (files, concepts)
>Describe the way your implementation works or what design decisions you made if applicable.
>Which are the main files and concepts you changed or introduced? -->

The `start-data-from-source.component.ts` is changed the most. I chose to define a boolean `measurementIsStarted` to keep track whether the measurement is started or not. This alters the button functionality of the start button to a stop button while also changing the pictogram from "play" (a play arrow) to "stop" (a stop square). 
Besides starting a measurement, clicking on the start button triggers a resets of all previously saved data. Clicking the stop button disconnects the user from the currently selected source.

All data services (`random-data.service.ts`, `live-data.service.ts`, `csv-file-import.service.ts`) now contain the functions `disconnect()` and `clearData()` where the functions in `csv-file-import.service.ts` are empty, hence non-functional, yet. Those changes were integrated in the `_availableSources` array of `data-source-selection.service.ts`.

To be consistent, the stop button was removed from `devicelist.component.ts` and its `HTML` file.

## How to test

### 1. Expected behavior
Clicking the play button should open the modal window of the source selection. There one should be able to select a source and start the measurement by clicking on "Start" or outside the modal window. To stop this measurement click on the play button which has now a stop square on it. The graph should still be visible. Pressing the play button again should delete the graph. Now the source can be selected and the measurement can be started again.
### 2. Steps to reproduce
*Not applicable.*
### 3. Is there still unexpected behaviour which needs to be addressed in the future?
If you click on "Clear selection" on the modal for source selection, or you have nothing selected yet, and then click outside of the modal, the start button is still a stop button. It resets to a play button by clicking on it.

I already tried to fix it, but it got more and more error prone. Maybe the functionality of the modal (or `data-source-selection.service`) needs to be changed to keep better track of if a measurement is active or not.