### PR TITLE
fix(stop): Fix start/stop for Car mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Formatting needs to be similar to the dataformat of the old OmnAIView data expor
 - Change start-data button to mat-icon play_arrow button (#107)
 - Update PR Template to be more clear (#93)
 - Update programm to v1.1.1 of the OmnAIScope Backend(#130)
+- Fix start/stop conditions for car mode(#131)
 
 
 ### Removed 

--- a/angular-frontend/src/app/source-selection/start-data-button.component.ts
+++ b/angular-frontend/src/app/source-selection/start-data-button.component.ts
@@ -44,7 +44,6 @@ export class StartDataButtonComponent {
             return;
         }
         else {
-            console.log("ich geh hier auch rein");
             const OmnAIScope = this.datasource.availableSources().find(s => s.id === 'omnaiscope');
             if (OmnAIScope) {
                 this.datasource.selectSource(OmnAIScope);

--- a/angular-frontend/src/app/source-selection/start-data-button.component.ts
+++ b/angular-frontend/src/app/source-selection/start-data-button.component.ts
@@ -25,7 +25,7 @@ export class StartDataButtonComponent {
     protected measurementIsStarted: boolean = false;
 
     clearAllData(): void {
-        this.datasource.availableSources().forEach( (source) => {
+        this.datasource.availableSources().forEach((source) => {
             source.clearData();
         });
     }
@@ -44,6 +44,7 @@ export class StartDataButtonComponent {
             return;
         }
         else {
+            console.log("ich geh hier auch rein");
             const OmnAIScope = this.datasource.availableSources().find(s => s.id === 'omnaiscope');
             if (OmnAIScope) {
                 this.datasource.selectSource(OmnAIScope);


### PR DESCRIPTION
## Checklist
Make sure you

- [x] have read the [contribution guidelines](../CONTRIBUTION.md),
- [x] given this PR a concise and imperative title, <!-- e.g. "Fix memory leak in DeviceService" or "Add dark-mode toggle" -->
- [x] have added necessary unit/e2e tests if necessary,
- [x] have added documentation if necessary,
- [x] have documented the changes in the [CHANGELOG.md](../CHANGELOG.md).

## 🛠 Type of change
<!-- Tick **all that apply** and delete the unused ones. -->

- [x] Bug fix

## Summary
<!-- A description of 1–3 sentences of what this PR does and *why*
What problem does this PR solve?
Which concept, bug, or requirement does it address? -->

Fix start/stop mechanic for car repair shop mode.

Problem: When stopping and directly starting a measurement in the car repair shop mode, no new data arises.

Reason: The stop button directly tries to open a new WS connection without the WS completly closing.

Solution: Add statemanagement to wait on WS closing before new WS connection is started

## 📝 Design Decisions
<!-- Changes in detail (files, concepts)
>Describe the way your implementation works or what design decisions you made if applicable.
>Which are the main files and concepts you changed or introduced? -->

Adding a WS closing and pendingOnWSClosing state to the connect and disconnect function. 

When WS is not closed and the start button is pressed, the connect function is returned, the pendingOnWSClosing variable is set to true and from the disconnect function that waits on the WS to close the connect() function is called again on closing. 

## How to test

### 1. Expected behavior
Connect an OmnAIScope 
Quickly start-->Stop-->start the measurement 

The measurement should start as expected 
