### PR TITLE
feat(loadData): Add csv load for Scope/Random data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Formatting needs to be similar to the dataformat of the old OmnAIView data expor
 - Add CI for Release (#123)
 - Add stop and delete functionality to start button (#126)
 - Add save button and save functionality (#134)
+- Add csv parser for OmnAIScope and Random Dummy data files (#136)
 
 
 ### Changed 

--- a/angular-frontend/src/app/omnai-datasource/csv-file-import/csv-file-import.service.ts
+++ b/angular-frontend/src/app/omnai-datasource/csv-file-import/csv-file-import.service.ts
@@ -3,14 +3,25 @@ import {DataSource} from '../../source-selection/data-source-selection.service';
 import {DataFormat} from '../omnai-scope-server/live-data.service';
 import {MatDialog} from '@angular/material/dialog';
 import {CsvFileSelectModalComponent} from './csv-file-select-modal.component';
+import { OldFormatParseService } from './oldFormatParser.service';
+import { genericFormatParserService } from './genericFormatParser.service';
 
 /**
  * The different errors, that can be thrown during file parsing
  */
-enum CsvFileImportErrorKind {
+export enum CsvFileImportErrorKind {
   FileEmpty = "The file is empty.",
   InvalidHeader = "The header of the File is malformed",
   InvalidSamplingSpeed = "The sampling speed could not be parsed.",
+}
+
+export interface ParsedFile{
+  name: string; 
+  data: DataFormat[]; 
+}
+export interface FileParser {
+  canParse(lines: string[]): boolean; 
+  parse(lines: string[]): ParsedFile; 
 }
 
 @Injectable({
@@ -29,75 +40,35 @@ export class CsvFileImportService implements DataSource {
   private readonly $data = signal<Record<string, DataFormat[]>>({});
   readonly data = this.$data.asReadonly();
 
-  /**
-   * Processes file content and transforms it into a record entry.
-   * If parsing goes wrong a {@link CsvFileImportErrorKind} is thrown.
-   *
-   * @param file File to be parsed
-   * @throws CsvFileImportErrorKind
-   * @private
-   */
-  private async processFile(file: File):Promise<{name: string, out: DataFormat[]}> {
-    //Ensure, that the file is not empty (contains no lines)
-    let text = await file.text();
-    let lines = text.split('\n');
-    if (lines.length < 1) throw CsvFileImportErrorKind.FileEmpty;
+  private readonly oldParser = inject(OldFormatParseService); 
+  private readonly generalParser = inject(genericFormatParserService); 
 
-    //The header of a file should be formed of 6 comma-seperated values:
-    //name,vin,kilometers,manufacturer,id,sampleRate
-    let info = lines[0].split(',');
-    if (info.length != 6) throw CsvFileImportErrorKind.InvalidHeader;
+  private readonly parsers: FileParser[] = [
+    this.oldParser, 
+    this.generalParser
+  ]; 
 
-    //sampleRate is the 5th index in the list above
-    //name should be the id, which is the 4th index
-    let name = info[4];
-    let sampleRate = Number(info[5]);
-    if (Number.isNaN(sampleRate) || !Number.isFinite(sampleRate))
-      throw CsvFileImportErrorKind.InvalidSamplingSpeed;
+  private async processFile(file: File): Promise<ParsedFile> {
+    const lines = (await file.text()).split(/\r?\n/);
 
-    //Internally the Graph render converts everything to Date object.
-    //The Date object constructor takes a number and interprets it as milliseconds since the Unix Epoch.
-    //Therefore, the Date object cannot represent any timepoint, that doesn't lie exactly on one millisecond.
-    //
-    //This code calculates how many different millisecond values we can represent (length) and which items represent those milliseconds (keepEvery).
-    let keepEvery = 1;
-    let length = (lines.length-1);
-    if (sampleRate > 1000) {
-      keepEvery = sampleRate/1000;
-      length = Math.ceil(length/sampleRate*1000);
+    for (const p of this.parsers) {
+      if (p.canParse(lines)) return p.parse(lines);
     }
-
-    //Pre-allocating the array, when you know the size is good practice.
-    //It makes it, so that data doesn't need to be moved, whilst adding more data
-    let out = new Array(length);
-    let arrayIndex = 0;
-
-    // keep only every 1 data-value of keepEvery
-    // the first line is the header of the file, so we need to skip it
-    for (let [index, sample] of lines.slice(1).entries()) {
-      if (keepEvery !== 0 && index % keepEvery !== 0) continue;
-      out[arrayIndex++] = {
-        timestamp: index/sampleRate*1000,
-        value: Number(sample),
-      };
-    }
-
-    return {
-      name,
-      out,
-    };
+    throw new Error('No suitable parser found');
   }
+
+
   private readonly dataFileChanged = effect(async ()=>{
     let files = this.files();
-    let data: Record<string, DataFormat[]> = {};
+    let result: Record<string, DataFormat[]> = {};
     for (let file of files) {
       try {
-        let {name, out} = await this.processFile(file);
-        data[name] = out;
+        let {name, data} = await this.processFile(file);
+        result[name] = data;
       } catch (e) {
         console.error(`There was an error, whilst parsing the file '${file.name}'. The file will be ignored. Error: ${e}`);
       }
     }
-    this.$data.set(data);
+    this.$data.set(result);
   });
 }

--- a/angular-frontend/src/app/omnai-datasource/csv-file-import/genericFormatParser.service.ts
+++ b/angular-frontend/src/app/omnai-datasource/csv-file-import/genericFormatParser.service.ts
@@ -1,0 +1,106 @@
+import { Injectable } from "@angular/core";
+import { FileParser, ParsedFile } from "./csv-file-import.service";
+import { DataFormat } from "../omnai-scope-server/live-data.service";
+
+/**
+ * Parse files with source/version header format 
+ */
+@Injectable({
+    providedIn: 'root'
+}) 
+export class genericFormatParserService implements FileParser {
+
+    canParse(lines: string[]){
+        return (
+            lines.length >= 2 &&
+            lines[0].startsWith('# source:') &&
+            lines[1].startsWith('# version:')
+        );
+    }
+
+    parse(lines: string[]): ParsedFile {
+        const source = lines[0].replace('# source:', '').trim();
+        const version = lines[1].replace('# version:', '').trim();
+        const body = lines.slice(2);
+
+        switch(`${source}:${version}`){
+            case 'OmnAIScope-DataServer:1.1.1': 
+                return this.parseScopev111(body); 
+            case 'dummy data:1.0.0': 
+                return this.parseDummyData(body); 
+            default : 
+                throw new Error ( `No parser for source registered`); 
+        }
+    }
+
+    parseScopev111(body: string[]): ParsedFile {
+        if (body.length < 3)
+            throw new Error('OmnAI‑CSV (1.1.1) contains no data.');
+
+        const idParts = body[0].split(',');
+        if (idParts.length < 2)
+            throw new Error('Header does not exist');
+
+        const name = idParts[1].trim();          // UUID
+        const SAMPLE_RATE = 100_000;            
+        const keepEvery   = SAMPLE_RATE > 1_000 
+            ? SAMPLE_RATE / 1_000                  
+            : 1;
+
+        const raw = body.slice(2)                // skip physical units 
+                        .filter(l => l.trim().length);   // delete empty lines 
+
+        if (raw.length === 0)
+            throw new Error('No measurement values found.');
+
+        /* CSV data has a timeshift thats needs to be calculated */ 
+        const firstTimeSec = Number(raw[0].split(',')[0].trim());
+        const timeShiftSec = -firstTimeSec;      
+
+        const data: DataFormat[] = [];
+        for (let i = 0; i < raw.length; i++) {
+            if (i % keepEvery) continue;           
+
+            const [tStr, vStr] = raw[i].split(',');
+            const tSec  = Number(tStr.trim()) + timeShiftSec;
+            const value = Number(vStr.trim());
+
+            if (!Number.isFinite(tSec) || Number.isNaN(value)) continue;
+
+            data.push({
+            timestamp: tSec * 1000,             
+            value,
+            });
+        }
+
+        return { name, data };
+    }
+
+    parseDummyData(body: string[]): ParsedFile {
+         if (body.length < 2) {
+            throw new Error('Dummy‑CSV does not contain data');
+        }
+
+        const data: DataFormat[] = [];
+
+        for (const line of body.slice(1)) {
+            if (line.trim().length === 0) continue;  
+
+            const [tsStr, valStr] = line.split(',');
+            const timestamp = Number(tsStr.trim());
+            const value      = Number(valStr.trim());
+
+            if (!Number.isFinite(timestamp) || Number.isNaN(value)) {
+            console.warn(`Line skipped (error): ${line}`);
+            continue;
+            }
+
+            data.push({ timestamp, value });
+        }
+
+        return {
+            name: 'dummy data', 
+            data,
+        };
+    }
+}

--- a/angular-frontend/src/app/omnai-datasource/csv-file-import/oldFormatParser.service.ts
+++ b/angular-frontend/src/app/omnai-datasource/csv-file-import/oldFormatParser.service.ts
@@ -1,0 +1,73 @@
+import { Injectable } from "@angular/core";
+import { FileParser } from "./csv-file-import.service";
+import { ParsedFile } from "./csv-file-import.service";
+import { CsvFileImportErrorKind } from "./csv-file-import.service";
+/**
+ * Parse files from old OmnAIView C++ Software 
+ */
+@Injectable({
+    providedIn: 'root'
+})
+export class OldFormatParseService implements FileParser {
+    canParse(lines: string[]) {
+        return lines.length > 0 && lines[0].split(',').length === 6;
+    }
+
+     /**
+     * Processes file content and transforms it into a record entry.
+     * If parsing goes wrong a {@link CsvFileImportErrorKind} is thrown.
+     *
+     * @param lines lines to be parsed 
+     * @throws CsvFileImportErrorKind
+     * @private
+      */
+
+    parse(lines: string[]): ParsedFile {
+        if (lines.length < 1) throw CsvFileImportErrorKind.FileEmpty;
+
+        //The header of a file should be formed of 6 comma-seperated values:
+        //name,vin,kilometers,manufacturer,id,sampleRate
+        let info = lines[0].split(',');
+        if (info.length != 6) throw CsvFileImportErrorKind.InvalidHeader;
+
+        //sampleRate is the 5th index in the list above
+        //name should be the id, which is the 4th index
+        let name = info[4];
+        let sampleRate = Number(info[5]);
+        if (Number.isNaN(sampleRate) || !Number.isFinite(sampleRate))
+        throw CsvFileImportErrorKind.InvalidSamplingSpeed;
+
+        //Internally the Graph render converts everything to Date object.
+        //The Date object constructor takes a number and interprets it as milliseconds since the Unix Epoch.
+        //Therefore, the Date object cannot represent any timepoint, that doesn't lie exactly on one millisecond.
+        //
+        //This code calculates how many different millisecond values we can represent (length) and which items represent those milliseconds (keepEvery).
+        let keepEvery = 1;
+        let length = (lines.length-1);
+        if (sampleRate > 1000) {
+        keepEvery = sampleRate/1000;
+        length = Math.ceil(length/sampleRate*1000);
+        }
+
+        //Pre-allocating the array, when you know the size is good practice.
+        //It makes it, so that data doesn't need to be moved, whilst adding more data
+        let out = new Array(length);
+        let arrayIndex = 0;
+
+        // keep only every 1 data-value of keepEvery
+        // the first line is the header of the file, so we need to skip it
+        for (let [index, sample] of lines.slice(1).entries()) {
+        if (keepEvery !== 0 && index % keepEvery !== 0) continue;
+        out[arrayIndex++] = {
+            timestamp: index/sampleRate*1000,
+            value: Number(sample),
+        };
+        }
+
+        return {
+        name,
+        data: out,
+        };   
+    }
+
+}


### PR DESCRIPTION
## Checklist
Make sure you

- [x] have read the [contribution guidelines](../CONTRIBUTION.md),
- [x] given this PR a concise and imperative title, <!-- e.g. "Fix memory leak in DeviceService" or "Add dark-mode toggle" -->
- [x] have added necessary unit/e2e tests if necessary,
- [x] have added documentation if necessary,
- [x] have documented the changes in the [CHANGELOG.md](../CHANGELOG.md).

## 🛠 Type of change
<!-- Tick **all that apply** and delete the unused ones. -->

- [x] New feature

## Summary
<!-- A description of 1–3 sentences of what this PR does and *why*
What problem does this PR solve?
Which concept, bug, or requirement does it address? -->

Add parser to load saved csv files from random dummy data server and OmnAIScope-DataServer.
File format is determined by source and version in file header

## 📝 Design Decisions
<!-- Changes in detail (files, concepts)
>Describe the way your implementation works or what design decisions you made if applicable.
>Which are the main files and concepts you changed or introduced? -->

Implement FileParser interface 

canParse()  tests if file is parsable by checking the header format and 
parse() returns a ParsedFile containing a name and data. 

The general file format is determined by the source and version key in the header. 
Seperated from this is the oldFileFormat from the old OmnAIView C++ software in an oldFormatParser. 

## How to test

### 1. Expected behavior
Save data from the Random Dummy data source or OmnAIScope . 
Open saved file with the "Load CSV Source" in the source selection. 
Data from the file should be now visible in the graph. 

