### PR TITLE
fix(zoom): Add correct startpoint for relative time 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added 
 ### Changed 
+- Fix relative time calculation for new zoom possibility
 ### Removed 
 
 ## [v1.7.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added 
-### Changed 
-- Fix relative time calculation for new zoom possibility
+### Changed
 ### Removed 
 
-## [v1.7.0]
+## [v1.7.1-alpha]
+
+### Changed 
+- Fix relative time calculation for new zoom possibility
+
+## [v1.7.0-alpha]
 
 ### Added 
 - Add settings menu dummy (#138)

--- a/angular-frontend/package.json
+++ b/angular-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "OmnAIView_angular",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "private": true,
   "dependencies": {
     "@angular/animations": "^20.0.2",

--- a/angular-frontend/src/app/graph/graph-data.service.ts
+++ b/angular-frontend/src/app/graph/graph-data.service.ts
@@ -35,6 +35,7 @@ export class DataSourceService {
   private readonly $graphDimensions = signal({ width: 800, height: 600 });
   private readonly $xDomain = signal<xDomainTuple>(defaultXDomain);
   private readonly $yDomain = signal([0, 100]);
+  readonly referenceStartTimestamp = signal<number | null>(null); // Reference the start timestamp of a measurement
   private readonly dataSourceSelectionService = inject(
     DataSourceSelectionService
   );
@@ -117,7 +118,10 @@ export class DataSourceService {
 
   private scaleAxisToData(data: UnwrapSignal<typeof this.dummySeries>) {
     console.log(data);
-    if (Object.keys(data).length === 0) return;
+    if (Object.keys(data).length === 0) {
+      this.referenceStartTimestamp.set(null);
+      return;
+    }
 
     const expandBy = 0.1;
 
@@ -139,6 +143,10 @@ export class DataSourceService {
       }),
       initial
     );
+
+    if (this.referenceStartTimestamp() === null) {
+      this.referenceStartTimestamp.set(result.minTimestamp);
+    }
 
     if (!isFinite(result.minTimestamp) || !isFinite(result.minValue)) return;
     const xDomainRange = result.maxTimestamp - result.minTimestamp;

--- a/angular-frontend/src/app/graph/graph.component.ts
+++ b/angular-frontend/src/app/graph/graph.component.ts
@@ -106,8 +106,9 @@ export class GraphComponent {
   updateXAxisInCanvas = effect(() => {
     if (!this.isInBrowser) return;
     const x = this.dataservice.xScale();
-    const domain = x.domain();
-    const formatter = makeXAxisTickFormatter(this.xAxisTimeMode(), domain[0]);
+    const t0 = this.dataservice.referenceStartTimestamp(); 
+    const baseline = t0 !== null ? new Date(t0) : x.domain()[0]; 
+    const formatter = makeXAxisTickFormatter(this.xAxisTimeMode(), baseline);
     const g = this.axesContainer().nativeElement;
     select(g)
       .transition(transition())

--- a/angular-frontend/src/app/graph/x-axis-formatter.utils.ts
+++ b/angular-frontend/src/app/graph/x-axis-formatter.utils.ts
@@ -2,10 +2,16 @@ import { type NumberValue, timeFormat } from "d3";
 
 export type xAxisMode = 'absolute' | 'relative';
 
+/**
+ * @brief Creates a tick-formatter for the X-Axis based on the mode 
+ * @param mode see {@link xAxisMode}
+ * @param startDate startdate relative time is calculated to  
+ * @returns tickformat function usable for d3
+ */
 export function makeXAxisTickFormatter(
   mode: xAxisMode,
-  domainStart: NumberValue | Date
-): (domainValue: NumberValue | Date, index: number) => string {
+  startDate: NumberValue | Date
+): (startValue: NumberValue | Date, index: number) => string {
   const formatAbsolute = timeFormat('%H:%M:%S');
   const formatRelative = timeFormat('%M:%S');
 
@@ -15,7 +21,7 @@ export function makeXAxisTickFormatter(
       return formatAbsolute(new Date(Number(d)));
     } else {
       const t = d instanceof Date ? d.getTime() : Number(d);
-      const t0 = domainStart instanceof Date ? domainStart.getTime() : Number(domainStart);
+      const t0 = startDate instanceof Date ? startDate.getTime() : Number(startDate);
       const elapsed = Math.max(0, t - t0);
       return formatRelative(new Date(elapsed));
     }

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "OmnAIView_electron",
   "productName": "OmnAIView",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "OmnAIView electron App",
   "main": "dist/main.js",
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omnaiview-parent",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Frontend for time-series data receiving, visualising and analysing",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
## Checklist
Make sure you

- [x] have read the [contribution guidelines](../CONTRIBUTION.md),
- [x] given this PR a concise and imperative title, <!-- e.g. "Fix memory leak in DeviceService" or "Add dark-mode toggle" -->
- [x] have added necessary unit/e2e tests if necessary,
- [x] have added documentation if necessary,
- [x] have documented the changes in the [CHANGELOG.md](../CHANGELOG.md).

## 🛠 Type of change
<!-- Tick **all that apply** and delete the unused ones. -->

- [x] Bug fix

## Summary
<!-- A description of 1–3 sentences of what this PR does and *why*
What problem does this PR solve?
Which concept, bug, or requirement does it address? -->

This PR fixes the calculation of relative time on the x-Axis for the random data server, by using correct start time for x-axis-formatter-util function. The issue appeared with the new zoom behavior. Mentioned in #137 . 

Problem: Previously the relative time was calculated from the current date as well as the start date of the domain.
Zooming changes the start data of the domain and therefore the relative time distance between the current date and the start date. This lead to wrongly calculated relative times when zooming.

Solution: Receive minTimestamp reference when a measurement starts. Use reference to calculate relative time to.

Issue number #98 

## 📝 Design Decisions
<!-- Changes in detail (files, concepts)
>Describe the way your implementation works or what design decisions you made if applicable.
>Which are the main files and concepts you changed or introduced? -->

Reference timestamp is set in the dataservice with the first call of scaleAxisToData in dataservice. Timestamp is reset when new measurement starts. 
Instead of using the domain start the date of the timestamp reference is used in the makeXAxisFormatter function of the graph component. 

## How to test

### 1. Expected behavior
Zooming in and out when using the random data server with relative timestamps, should lead to no offset between timestamps and data in the graph, that depends on the zoom state. 

### 2. Steps to reproduce
Start the application in angular mode. Start a measurement with the random dataserver by clicking play and selecting a datasource. Zoom in and out with the mouse wheel or drag the measurement by clicking in the graph. You should see the expected behavior. 

### 3. Is there still unexpected behaviour which needs to be addressed in the future?
This PR only fixes part 1 of issue #98. 
