### PR TITLE
fix(graph-selection): correct selection rectangle positioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed 
 ### Removed 
 
-## [v1.12.0]
+
+## [v1.12.1-alpha]
+
+### Fixed
+- Fix selection rectangle positioning to properly align with plot area boundaries
+
+## [v1.12.0-alpha]
 
 ### Added
 - Add interactive graph selection analysis tool for time-series measurement data

--- a/angular-frontend/package.json
+++ b/angular-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "OmnAIView_angular",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "private": true,
   "dependencies": {
     "@angular/animations": "^20.0.2",

--- a/angular-frontend/src/app/graph/graph.component.html
+++ b/angular-frontend/src/app/graph/graph.component.html
@@ -35,7 +35,7 @@
         <rect
           class="selection-rect"
           [attr.x]="rect.x - dataservice.margin.left"
-          [attr.y]="rect.y - dataservice.margin.top"
+          [attr.y]="rect.y"
           [attr.width]="rect.width"
           [attr.height]="rect.height"
         />

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "OmnAIView_electron",
   "productName": "OmnAIView",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "OmnAIView electron App",
   "main": "dist/main.js",
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omnaiview-parent",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "Frontend for time-series data receiving, visualising and analysing",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
## Checklist
Make sure you

- [x] have read the [contribution guidelines](../CONTRIBUTION.md),
- [x] given this PR a concise and imperative title, <!-- e.g. "Fix memory leak in DeviceService" or "Add dark-mode toggle" -->
- [ ] have added necessary unit/e2e tests if necessary,
- [ ] have added documentation if necessary,
- [ ] have documented the changes in the [CHANGELOG.md](../CHANGELOG.md).

## 🛠 Type of change
<!-- Tick **all that apply** and delete the unused ones. -->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional change)
- [ ] Docs / examples
- [ ] CI / tooling

## Summary
Fixes selection rectangle positioning issue where the rectangle starts above the plot area and ends before reaching the bottom boundary. The selection rectangle now properly aligns with the plot area boundaries.

## Problem
The Y-coordinate was being double-adjusted:
- Service sets `y: 0` (relative to plot area)
- Template applied `rect.y - margin.top` = `0 - 20px = -20px`
- Result: Rectangle started 20px above the plot area

## Solution
Remove margin adjustment in template since the rectangle is already positioned within the margin-transformed SVG group element.

```html
<!-- Before -->
[attr.y]="rect.y - dataservice.margin.top"

<!-- After -->  
[attr.y]="rect.y"

