### PR TITLE
chore: remove inactive code owner @akmaily from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # this is the list of code owners that are automatically set as code
 # reviewers for a new PR 
-*   @tabeatheunicorn @akmaily @PhilippTheServer @MaxClerkwell
+*   @tabeatheunicorn @PhilippTheServer @MaxClerkwell
 
 # list of codeowners that are set as code reviewers for md files 
-*.md   @tabeatheunicorn @akmaily @dobe-1 @MaxClerkwell @odinthenerd @PhilippTheServer 
+*.md   @tabeatheunicorn @dobe-1 @MaxClerkwell @odinthenerd @PhilippTheServer 


### PR DESCRIPTION
## Goal

Stop auto-requesting reviews from `@akmaily`, who is no longer an active contributor.

## Why

`@akmaily` is listed in both rules of `.github/CODEOWNERS`, so GitHub automatically adds her as a requested reviewer on nearly every PR (any file via `*`, plus every `*.md` change). Since she is no longer active, these requests just add noise and block review flows.

## Change

Remove `@akmaily` from both CODEOWNERS rules. All other code owners remain unchanged. No functional change.